### PR TITLE
Update core exports

### DIFF
--- a/catma_core/__init__.py
+++ b/catma_core/__init__.py
@@ -1,14 +1,14 @@
 """Core functionality for Catma."""
 
-from .model import Object, Morphism, Functor
-from .io_yaml import read_catmaml, write_catmaml
-from .validate import is_valid_category
+from .model import Obj, Morphism, Category
+from .io_yaml import load_yaml, dump_yaml
+from .validate import validate
 
 __all__ = [
-    "Object",
+    "Obj",
     "Morphism",
-    "Functor",
-    "read_catmaml",
-    "write_catmaml",
-    "is_valid_category",
+    "Category",
+    "load_yaml",
+    "dump_yaml",
+    "validate",
 ]


### PR DESCRIPTION
## Summary
- replace outdated imports in `catma_core.__init__` with current model, IO, and validation interfaces
- expose only the current API symbols via `__all__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68bca5bf074c83249cba7e3206b91118