### PR TITLE
Update YAML loader and validation usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ pip install -e .
 ## Usage
 
 ```python
-from catma_core.io_yaml import read_catmaml
-from catma_core.validate import is_valid_category
+from catma_core.io_yaml import load_yaml
+from catma_core.validate import validate
 
-cfg = read_catmaml("examples/ak_fsio.yaml")
-print(is_valid_category(cfg))
+cat = load_yaml("examples/ak_fsio.yaml")
+print(validate(cat))
 ```

--- a/catma_core/__init__.py
+++ b/catma_core/__init__.py
@@ -1,14 +1,22 @@
-"""Core functionality for Catma."""
+"""Core functionality for Catma.
 
-from .model import Object, Morphism, Functor
-from .io_yaml import read_catmaml, write_catmaml
-from .validate import is_valid_category
+This package exposes the primary data structures and helpers used
+throughout the project.  Earlier iterations of the library provided
+``read_catmaml`` and ``is_valid_category`` helper functions which have
+since been replaced with the more explicit ``load_yaml`` and
+``validate`` functions.  The exports below mirror the current API so
+that consumers can simply import from :mod:`catma_core`.
+"""
+
+from .model import Obj, Morphism, Category
+from .io_yaml import load_yaml, dump_yaml
+from .validate import validate
 
 __all__ = [
-    "Object",
+    "Obj",
     "Morphism",
-    "Functor",
-    "read_catmaml",
-    "write_catmaml",
-    "is_valid_category",
+    "Category",
+    "load_yaml",
+    "dump_yaml",
+    "validate",
 ]

--- a/examples/ak_fsio.yaml
+++ b/examples/ak_fsio.yaml
@@ -1,4 +1,13 @@
-{
-  "objects": [{"name": "A"}, {"name": "B"}],
-  "morphisms": [{"name": "f", "source": "A", "target": "B"}]
-}
+---
+version: 0.1
+category: AK_FSIO
+objects:
+  - id: A
+    labels: []
+  - id: B
+    labels: []
+morphisms:
+  - id: f
+    src: A
+    dst: B
+    kind: morphism

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,13 +1,16 @@
 from pathlib import Path
 import sys
 
+# Ensure the package root is on the path when running tests directly
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from catma_core import io_yaml, validate
+from catma_core.io_yaml import load_yaml
+from catma_core.validate import validate
 
 
-def test_read_ak_fsio():
+def test_load_ak_fsio():
     path = Path(__file__).resolve().parent.parent / "examples" / "ak_fsio.yaml"
-    data = io_yaml.read_catmaml(path)
-    assert data["objects"][0]["name"] == "A"
-    assert validate.is_valid_category(data)
+    cat = load_yaml(path)
+    assert "A" in cat.objects
+    assert cat.morphisms["f"].src == "A"
+    assert validate(cat) == []


### PR DESCRIPTION
## Summary
- expose new load_yaml/dump_yaml/validate API in catma_core
- refresh documentation and examples to use load_yaml and validate
- update test to load Category dataclass and validate it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca5c3478c8324a5762bff378d9acf