### PR TITLE
Use for-loop for error messages

### DIFF
--- a/catma_ui/app.py
+++ b/catma_ui/app.py
@@ -13,6 +13,8 @@ if uploaded:
     st.write(f"Category: **{cat.name}**")
     errs = validate(cat)
     if errs:
-        st.error("Validation issues:"); [st.write(f"- {e}") for e in errs]
+        with st.error("Validation issues:"):
+            for e in errs:
+                st.write(f"- {e}")
     img = render_graph(cat, out_path="/tmp/catma_graph")
     st.image(img, caption="Rendered Category")


### PR DESCRIPTION
## Summary
- Replace list comprehension with for-loop to display validation errors in the Streamlit app

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Object' from 'catma_core.model')*

------
https://chatgpt.com/codex/tasks/task_e_68bca5c46a048324a0b36ea41ed37294