### PR TITLE
Remove unused imports from core modules

### DIFF
--- a/catma_core/model.py
+++ b/catma_core/model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple
 
 @dataclass(frozen=True)
 class Obj:

--- a/catma_core/validate.py
+++ b/catma_core/validate.py
@@ -1,4 +1,4 @@
-from .model import Category, Morphism
+from .model import Category
 
 def check_objects_exist(cat: Category) -> list[str]:
     errs = []


### PR DESCRIPTION
## Summary
- Drop unused `Optional` from `catma_core.model`
- Remove unused `Morphism` import in validator

## Testing
- `ruff check --select F401 .`
- `pytest` *(fails: ImportError: cannot import name 'Object' from 'catma_core.model')*

------
https://chatgpt.com/codex/tasks/task_e_68bca5c5b32c8324ac26f1d1f2b1f11a