### PR TITLE
Add docstrings to core utilities

### DIFF
--- a/catma_core/io_yaml.py
+++ b/catma_core/io_yaml.py
@@ -1,7 +1,15 @@
 import yaml
 from .model import Obj, Morphism, Category
 
+
 def load_yaml(path: str) -> Category:
+    """Load a :class:`Category` from a YAML file.
+
+    The YAML document must define ``objects`` as a list of mappings with
+    ``id`` and optional ``labels`` keys and may define ``morphisms`` with
+    ``id``, ``src``, ``dst`` and ``kind``.  The function returns the
+    corresponding :class:`Category` instance.
+    """
     with open(path, "r", encoding="utf-8") as f:
         y = yaml.safe_load(f)
     objs = {o["id"]: Obj(id=o["id"], labels=tuple(o.get("labels", []))) for o in y["objects"]}
@@ -11,7 +19,18 @@ def load_yaml(path: str) -> Category:
     }
     return Category(name=y.get("category", "Unnamed"), objects=objs, morphisms=morphs)
 
+
 def dump_yaml(cat: Category, path: str) -> None:
+    """Write a :class:`Category` to a YAML file.
+
+    Parameters
+    ----------
+    cat:
+        Category to serialize.  Object labels and morphism attributes are
+        preserved.
+    path:
+        Destination path for the YAML document.
+    """
     y = {
         "version": "0.1",
         "category": cat.name,

--- a/catma_core/render.py
+++ b/catma_core/render.py
@@ -1,13 +1,29 @@
 from graphviz import Digraph
 from .model import Category
 
+
 def render_graph(cat: Category, out_path: str = "catma_graph"):
+    """Render *cat* to a PNG using Graphviz.
+
+    Parameters
+    ----------
+    cat:
+        Category to visualise.
+    out_path:
+        Path prefix for the generated file; ``.png`` is appended.
+
+    Returns
+    -------
+    str
+        Path to the rendered image.
+    """
     g = Digraph(comment=cat.name, format="png")
     for o in cat.objects.values():
         g.node(o.id, f"{o.id}\n{', '.join(o.labels)}")
     for m in cat.morphisms.values():
         label = m.kind
-        if "weight" in m.attrs: label += f" ({m.attrs['weight']})"
+        if "weight" in m.attrs:
+            label += f" ({m.attrs['weight']})"
         g.edge(m.src, m.dst, label=label)
     g.render(out_path, cleanup=True)
     return out_path + ".png"

--- a/catma_core/validate.py
+++ b/catma_core/validate.py
@@ -1,17 +1,52 @@
 from .model import Category, Morphism
 
+
 def check_objects_exist(cat: Category) -> list[str]:
+    """Ensure that every morphism references existing objects.
+
+    Parameters
+    ----------
+    cat:
+        Category whose morphisms are to be checked.
+
+    Returns
+    -------
+    list[str]
+        Error messages for morphisms with missing source or destination
+        objects.
+    """
     errs = []
     for m in cat.morphisms.values():
-        if m.src not in cat.objects: errs.append(f"morphism {m.id}: src {m.src} missing")
-        if m.dst not in cat.objects: errs.append(f"morphism {m.id}: dst {m.dst} missing")
+        if m.src not in cat.objects:
+            errs.append(f"morphism {m.id}: src {m.src} missing")
+        if m.dst not in cat.objects:
+            errs.append(f"morphism {m.id}: dst {m.dst} missing")
     return errs
 
+
 def check_identities(cat: Category) -> list[str]:
+    """Placeholder for identity checks.
+
+    Intended to verify that each object has an identity morphism.  Currently
+    returns an empty list.
+    """
     # v0.1: just ensure each object could have an identity (not enforced creation)
     return []
 
+
 def validate(cat: Category) -> list[str]:
+    """Run all validation helpers and collect their error messages.
+
+    Parameters
+    ----------
+    cat:
+        Category to validate.
+
+    Returns
+    -------
+    list[str]
+        All accumulated error strings from individual checks.
+    """
     errs = []
     errs += check_objects_exist(cat)
     errs += check_identities(cat)


### PR DESCRIPTION
## Summary
- document YAML load and dump helpers
- explain render_graph behaviour and parameters
- describe validation helpers for category consistency

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Object' from 'catma_core.model')*

------
https://chatgpt.com/codex/tasks/task_e_68bca5c7f9d083248b842d40a7e904bf